### PR TITLE
Upgrading AWS SDK to 1.10.68

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalacOptions ++= Seq(
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-val awsSdkVersion = "1.9.39"
+val awsSdkVersion = "1.10.16"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-codedeploy" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalacOptions ++= Seq(
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-val awsSdkVersion = "1.10.16"
+val awsSdkVersion = "1.10.68"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-codedeploy" % awsSdkVersion,


### PR DESCRIPTION
Seeing what looks like some incompatability between the 1.9 sdk and 1.10,
possibly related to the sbt-cloudformation dependency:

java.lang.NoSuchMethodError: com.amazonaws.AmazonWebServiceRequest.copyPrivateRequestParameters()

Hopefully this will resolve, but even if not at least we'll be a little more
up to date.